### PR TITLE
fix: missing orElse in maybeWhen interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+* Added missing `orElse` in `maybeWhen` interface.
+
 ## 1.1.0
 
 * Added `maybeWhen` method to handle specific states.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -63,7 +63,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.1.1"
   equatable:
     dependency: transitive
     description:

--- a/lib/src/do.dart
+++ b/lib/src/do.dart
@@ -134,6 +134,7 @@ abstract interface class Do<F, S> {
     T Function()? onLoading,
     T Function(S value)? onSuccess,
     T Function(F failure)? onFailure,
+    T Function()? orElse,
   });
 
   /// Executes the [onTry] function and returns a [So] if is a [Do] object.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: doso
 description: "DoSo is a lightweight Dart library for simple and elegant error and state handling, designed to reduce boilerplate and avoid code generation in Flutter apps."
-version: 1.1.0
+version: 1.1.1
 repository: https://github.com/grupo-sbf/DoSo
 issue_tracker: https://github.com/grupo-sbf/DoSo/issues
 homepage: https://github.com/grupo-sbf/DoSo


### PR DESCRIPTION
This pull request introduces version 1.1.1 of the `doso` library, focusing on enhancing functionality and updating documentation. The most significant change is the addition of the `orElse` parameter to the `maybeWhen` interface, which provides a fallback option for unhandled cases.

### Enhancements to the `maybeWhen` interface:
* [`lib/src/do.dart`](diffhunk://#diff-fd3ac67a77c88138ce8089efe763ea530fb7ee7ab2e25d892dd00ba82f1b92e5R137): Added a new `T Function()? orElse` parameter to the `maybeWhen` interface to handle fallback scenarios when no specific state matches.

### Documentation updates:
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R4): Added an entry for version 1.1.1, documenting the addition of the `orElse` parameter to the `maybeWhen` interface.

### Versioning:
* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L3-R3): Updated the library version from `1.1.0` to `1.1.1` to reflect the new changes.