### PR TITLE
fix: catch exception when onCatch is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.1
+## 1.1.2
 
 * Fixed `tryCatch` method when onCatch is null.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.1.1
 
+* Fixed `tryCatch` method when onCatch is null.
+
+## 1.1.1
+
 * Added missing `orElse` in `maybeWhen` interface.
 
 ## 1.1.0

--- a/README.md
+++ b/README.md
@@ -271,3 +271,9 @@ combine it with other libraries like `flutter_bloc` or `provider` for state mana
 Check out the full implementation, open issues, and contribute on GitHub: [DoSo on GitHub](https://github.com/grupo-sbf/DoSo)
 
 ---
+
+## 📌 Feature Ready
+
+This package is **feature ready**, meaning all planned features have been implemented and it is stable. As such, it's common that there won't be frequent changes or updates for a while. Bug fixes and critical improvements will still be addressed as needed.
+
+---

--- a/lib/src/do.dart
+++ b/lib/src/do.dart
@@ -180,13 +180,13 @@ abstract interface class Do<F, S> {
       return Do.success(result);
     } on Exception catch (e, s) {
       if (onCatch == null) {
-        return Do.failure(e as F);
+        return Do.failure(Exception(e.toString()));
       }
 
       return Do.failure(onCatch(e, s));
     } catch (e, s) {
       if (onCatch == null) {
-        return Do.failure(e as F);
+        return Do.failure(Exception(e.toString()));
       }
 
       return Do.failure(onCatch(Exception(e.toString()), s));

--- a/lib/src/so.dart
+++ b/lib/src/so.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'do.dart';
 
-/// A type alias for a function that returns a `FutureOr` of type `Do<S, F>`.
+/// A type alias for a function that returns a `FutureOr` of type `Do<F, S>`.
 ///
 /// This is used to represent a computation that may succeed or fail.
 /// The type parameters [S] and [F] represent the success and failure types,
@@ -10,7 +10,7 @@ import 'do.dart';
 ///
 /// This type alias is useful for defining functions that perform asynchronous
 /// operations and return a result wrapped in a [Do] object.
-/// The [So] type alias is a shorthand for `FutureOr<Do<S, F>>`, which means
+/// The [So] type alias is a shorthand for `FutureOr<Do<F, S>>`, which means
 /// that the function can return either a `Future` or a synchronous
 /// `Do` object.
 ///
@@ -25,7 +25,7 @@ import 'do.dart';
 /// either return a successful response or an error.
 ///
 /// ```dart
-/// So<String, Exception> fetchData() async {
+/// So<Exception, String> fetchData() async {
 ///  return Do.tryCatch(
 ///    onTry: () async {
 ///     final response = await http.get('https://api.example.com/data');
@@ -43,7 +43,7 @@ import 'do.dart';
 /// ```
 typedef So<F, S> = FutureOr<Do<F, S>>;
 
-/// A type alias for a function that returns a `FutureOr` of type `Do<S, Exception>`.
+/// A type alias for a function that returns a `FutureOr` of type `Do<Exception, S>`.
 ///
 /// This is used to represent a computation that may succeed or fail with an
 /// exception.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: doso
 description: "DoSo is a lightweight Dart library for simple and elegant error and state handling, designed to reduce boilerplate and avoid code generation in Flutter apps."
-version: 1.1.1
+version: 1.1.2
 repository: https://github.com/grupo-sbf/DoSo
 issue_tracker: https://github.com/grupo-sbf/DoSo/issues
 homepage: https://github.com/grupo-sbf/DoSo


### PR DESCRIPTION
We needed to fix the usage of tryCatch, the F was setting as dynamic and it was throwing errors in the apps.