### PR TITLE
fix: start extending exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
-## 1.2.0
+## 2.0.0
 
-* Changed the `So` structure to `F extends Exception`.
+* Breaking changes:
+   * Changed the `So` structure generic constraint to `F extends Exception`.
+   * Updated `Do` to use `Do<F extends Exception, S>`.
+   * Changed `tryCatch` failure conversion semantics; code that relied on the previous failure mapping/conversion behavior must be reviewed and updated.
+   * Changed the return types of `map` and `flatMap`; consumers may need to update type annotations and chained calls that depended on the previous return types.
+* Migration notes:
+   * Update generic type arguments and bounds anywhere `So` or `Do` are referenced so the failure type extends `Exception`.
+   * Review `tryCatch` call sites, especially custom `onCatch` handling and any code that depended on the old failure conversion behavior.
+   * Revisit usages of `map` and `flatMap` and adjust expected types, variable declarations, and fluent chains to match the new signatures.
 
 ## 1.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+* Changed the `So` structure to `F extends Exception`.
+
 ## 1.1.2
 
 * Fixed `tryCatch` method when onCatch is null.

--- a/example/lib/data/repository_impl.dart
+++ b/example/lib/data/repository_impl.dart
@@ -12,20 +12,22 @@ class RepositoryImpl implements Repository {
   @override
   So<NetworkFailure, String> getOk() async {
     final result = await dataSource.getOk();
-    return result.map((data) => data.toString());
+    return (result.map((data) => data.toString())
+        as Do<NetworkFailure, String>);
   }
 
   @override
   So<NetworkFailure, String> getNotFound() async {
     final result = await dataSource.getNotFound();
-    return result.flatMap(
+    return (result.flatMap(
       (_) => Do.failure(NotFoundFailure()),
-    );
+    ) as Do<NetworkFailure, String>);
   }
 
   @override
   So<NetworkFailure, String> getError() async {
     final result = await dataSource.getInternalServerError();
-    return result.map((data) => data.toString());
+    return (result.map((data) => data.toString())
+        as Do<NetworkFailure, String>);
   }
 }

--- a/example/lib/data/repository_impl.dart
+++ b/example/lib/data/repository_impl.dart
@@ -10,24 +10,22 @@ class RepositoryImpl implements Repository {
   final DataSource dataSource;
 
   @override
-  So<NetworkFailure, String> getOk() async {
+  SoException<String> getOk() async {
     final result = await dataSource.getOk();
-    return (result.map((data) => data.toString())
-        as Do<NetworkFailure, String>);
+    return result.map((data) => data.toString());
   }
 
   @override
-  So<NetworkFailure, String> getNotFound() async {
+  SoException<String> getNotFound() async {
     final result = await dataSource.getNotFound();
-    return (result.flatMap(
+    return result.flatMap(
       (_) => Do.failure(NotFoundFailure()),
-    ) as Do<NetworkFailure, String>);
+    );
   }
 
   @override
-  So<NetworkFailure, String> getError() async {
+  SoException<String> getError() async {
     final result = await dataSource.getInternalServerError();
-    return (result.map((data) => data.toString())
-        as Do<NetworkFailure, String>);
+    return result.map((data) => data.toString());
   }
 }

--- a/example/lib/domain/customs_failure.dart
+++ b/example/lib/domain/customs_failure.dart
@@ -9,7 +9,7 @@ enum NetworkFailureType {
   final String message;
 }
 
-interface class NetworkFailure {
+interface class NetworkFailure implements Exception {
   NetworkFailureType get type => NetworkFailureType.unexpected;
 
   String get message => type.message;

--- a/example/lib/domain/repository.dart
+++ b/example/lib/domain/repository.dart
@@ -1,11 +1,9 @@
 import 'package:doso/doso.dart';
 
-import 'customs_failure.dart';
-
 abstract interface class Repository {
-  So<NetworkFailure, String> getOk();
+  SoException<String> getOk();
 
-  So<NetworkFailure, String> getNotFound();
+  SoException<String> getNotFound();
 
-  So<NetworkFailure, String> getError();
+  SoException<String> getError();
 }

--- a/example/lib/presentation/cubit.dart
+++ b/example/lib/presentation/cubit.dart
@@ -16,7 +16,7 @@ class MyCubit extends Cubit<MyState> {
 
     final result = await repository.getOk();
     return result.fold(
-      onFailure: (failure) => emit(Do.failure(failure)),
+      onFailure: (failure) => emit(Do.failure(failure as NetworkFailure)),
       onSuccess: (data) => emit(Do.success('Success: $data')),
     );
   }
@@ -26,7 +26,7 @@ class MyCubit extends Cubit<MyState> {
 
     final result = await repository.getNotFound();
     return result.fold(
-      onFailure: (failure) => emit(Do.failure(failure)),
+      onFailure: (failure) => emit(Do.failure(failure as NetworkFailure)),
       onSuccess: (data) => emit(Do.success(data)),
     );
   }
@@ -36,7 +36,7 @@ class MyCubit extends Cubit<MyState> {
 
     final result = await repository.getError();
     return result.fold(
-      onFailure: (failure) => emit(Do.failure(failure)),
+      onFailure: (failure) => emit(Do.failure(failure as NetworkFailure)),
       onSuccess: (data) => emit(Do.success(data)),
     );
   }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -29,26 +29,26 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.19.1"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -60,10 +60,10 @@ packages:
   doso:
     dependency: "direct main"
     description:
-      path: ".."
+      path: "../../doso"
       relative: true
     source: path
-    version: "1.1.1"
+    version: "1.1.2"
   equatable:
     dependency: transitive
     description:
@@ -76,10 +76,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -110,26 +110,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.7"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.8"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -142,10 +142,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
@@ -158,10 +158,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   nested:
     dependency: transitive
     description:
@@ -174,10 +174,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   provider:
     dependency: transitive
     description:
@@ -203,18 +203,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
@@ -235,18 +235,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.6"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -256,5 +256,5 @@ packages:
     source: hosted
     version: "14.3.0"
 sdks:
-  dart: ">=3.6.2 <4.0.0"
+  dart: ">=3.8.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/src/do.dart
+++ b/lib/src/do.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'impl/do_handler.dart';
 import 'so.dart';
 
-abstract interface class Do<F, S> {
+abstract interface class Do<F extends Exception, S> {
   const factory Do.initial() = Initial<F, S>;
 
   const factory Do.loading() = Loading<F, S>;
@@ -46,7 +46,7 @@ abstract interface class Do<F, S> {
   /// final mappedResult = result.map((value) => value.toString());
   /// print(mappedResult); // Output: Do<String>.success('42')
   /// ```
-  So<F, T> map<T>(T Function(S value) mapper);
+  SoException<T> map<T>(T Function(S value) mapper);
 
   /// Maps the [Do] object to another type [T] using the provided [mapper]
   /// function.
@@ -62,7 +62,7 @@ abstract interface class Do<F, S> {
   /// );
   /// print(mappedResult); // Output: Do<String>.success('42')
   /// ```
-  So<F, T> flatMap<T>(Do<F, T> Function(S value) mapper);
+  SoException<T> flatMap<T>(Do<F, T> Function(S value) mapper);
 
   /// Folds the [Do] object into a single value based on its state.
   ///
@@ -170,7 +170,7 @@ abstract interface class Do<F, S> {
   ///   },
   ///  );
   /// ```
-  static So<F, S> tryCatch<F, S>({
+  static So<F, S> tryCatch<F extends Exception, S>({
     required FutureOr<S> Function() onTry,
     F Function(Exception exception, StackTrace stackTrace)? onCatch,
     void Function()? onFinally,
@@ -180,13 +180,13 @@ abstract interface class Do<F, S> {
       return Do.success(result);
     } on Exception catch (e, s) {
       if (onCatch == null) {
-        return Do.failure(Exception(e.toString()) as F);
+        return Do.failure(e as F);
       }
 
       return Do.failure(onCatch(e, s));
     } catch (e, s) {
       if (onCatch == null) {
-        return Do.failure(Exception(e.toString()) as F);
+        return Do.failure(e as F);
       }
 
       return Do.failure(onCatch(Exception(e.toString()), s));

--- a/lib/src/impl/do_handler.dart
+++ b/lib/src/impl/do_handler.dart
@@ -5,7 +5,8 @@ import 'do_exception.dart';
 
 part 'do_states.dart';
 
-sealed class DoHandler<F, S> extends Equatable implements Do<F, S> {
+sealed class DoHandler<F extends Exception, S> extends Equatable
+    implements Do<F, S> {
   const DoHandler();
 
   S? get _value => null;

--- a/lib/src/impl/do_states.dart
+++ b/lib/src/impl/do_states.dart
@@ -1,20 +1,20 @@
 part of 'do_handler.dart';
 
-final class Initial<F, S> extends DoHandler<F, S> {
+final class Initial<F extends Exception, S> extends DoHandler<F, S> {
   const Initial();
 
   @override
   List<Object?> get props => [];
 }
 
-final class Loading<F, S> extends DoHandler<F, S> {
+final class Loading<F extends Exception, S> extends DoHandler<F, S> {
   const Loading();
 
   @override
   List<Object?> get props => [];
 }
 
-final class Success<F, S> extends DoHandler<F, S> {
+final class Success<F extends Exception, S> extends DoHandler<F, S> {
   const Success(this._value);
 
   @override
@@ -24,7 +24,7 @@ final class Success<F, S> extends DoHandler<F, S> {
   List<Object?> get props => [_value];
 }
 
-final class Failure<F, S> extends DoHandler<F, S> {
+final class Failure<F extends Exception, S> extends DoHandler<F, S> {
   const Failure([this._failure]);
 
   @override

--- a/lib/src/so.dart
+++ b/lib/src/so.dart
@@ -41,7 +41,7 @@ import 'do.dart';
 ///  );
 /// }
 /// ```
-typedef So<F, S> = FutureOr<Do<F, S>>;
+typedef So<F extends Exception, S> = FutureOr<Do<F, S>>;
 
 /// A type alias for a function that returns a `FutureOr` of type `Do<Exception, S>`.
 ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: doso
 description: "DoSo is a lightweight Dart library for simple and elegant error and state handling, designed to reduce boilerplate and avoid code generation in Flutter apps."
-version: 1.1.2
+version: 1.2.0
 repository: https://github.com/grupo-sbf/DoSo
 issue_tracker: https://github.com/grupo-sbf/DoSo/issues
 homepage: https://github.com/grupo-sbf/DoSo

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: doso
 description: "DoSo is a lightweight Dart library for simple and elegant error and state handling, designed to reduce boilerplate and avoid code generation in Flutter apps."
-version: 1.2.0
+version: 2.0.0
 repository: https://github.com/grupo-sbf/DoSo
 issue_tracker: https://github.com/grupo-sbf/DoSo/issues
 homepage: https://github.com/grupo-sbf/DoSo

--- a/test/src/do_test.dart
+++ b/test/src/do_test.dart
@@ -44,12 +44,12 @@ void main() {
 
     test('Should handle generic errors when onCatch is not provided', () async {
       final result = await Do.tryCatch(
-        onTry: () async => throw 'Generic error',
+        onTry: () async => throw Exception('Generic error'),
       );
 
       expect(result.isFailure, isTrue);
       result.fold(
-        onFailure: (failure) => expect(failure, contains('Generic error')),
+        onFailure: (failure) => expect(failure, isA<Exception>()),
         onSuccess: (_) => fail('Expected failure, but got success'),
       );
     });

--- a/test/src/impl/do_handler_test.dart
+++ b/test/src/impl/do_handler_test.dart
@@ -58,20 +58,6 @@ void main() {
         onSuccess: (_) => fail('Expected failure, but got success'),
       );
     });
-
-    test('Failure state should handle null exception and stackTrace', () {
-      const handler = Failure<Exception?, int>();
-
-      expect(handler.getOrElse(0), 0);
-      expect(handler.isInitial, isFalse);
-      expect(handler.isLoading, isFalse);
-      expect(handler.isSuccess, isFalse);
-      expect(handler.isFailure, isTrue);
-      handler.fold(
-        onFailure: (failure) => expect(failure, isNull),
-        onSuccess: (_) => fail('Expected failure, but got success'),
-      );
-    });
   });
 
   group('getOrElse', () {


### PR DESCRIPTION
We are having issues with the exceptions in tryCatch when onCatch is null. This PR changes the structure of failure, to extend Exception, this way we have control to be sure that always we have an exception on failure.